### PR TITLE
[LIB-337] CI should automatically bump JS lib version 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,19 @@ machine:
   node:
     version: 4.2.3
 
+checkout:
+  post:
+    - git config --global user.email "$GITHUB_EMAIL"
+    - git config --global user.name "$GITHUB_NAME"
+
 test:
   override:
     - npm run-script test-with-coverage
     - npm run-script codeclimate
+
+deployment:
+  publish:
+    branch: master
+    owner: syncano
+    commands:
+      - npm run-script build-and-publish

--- a/package.json
+++ b/package.json
@@ -8,14 +8,21 @@
   },
   "author": "Kelly Andrews",
   "contributors": [
-    {"name": "Jakub Bilko", "email": "jakub.bilko@syncano.com"},
-    {"name": "Daniel Kopka", "email": "daniel.kopka@syncano.com"}
+    {
+      "name": "Jakub Bilko",
+      "email": "jakub.bilko@syncano.com"
+    },
+    {
+      "name": "Daniel Kopka",
+      "email": "daniel.kopka@syncano.com"
+    }
   ],
   "license": "ISC",
   "scripts": {
     "codeclimate": "codeclimate-test-reporter < ./coverage/lcov.info",
     "prebuild": "rimraf lib",
     "build": "babel ./src --out-dir ./lib",
+    "build-and-publish": "gulp build-and-publish",
     "prepublish": "npm run build",
     "test": "mocha 'test/specs/**/*.js'",
     "test-with-coverage": "istanbul cover _mocha -- 'test/specs/**/*.js'"
@@ -31,12 +38,14 @@
   },
   "devDependencies": {
     "aliasify": "^1.8.0",
+    "async": "^1.5.0",
     "babel": "^5.8.34",
     "babel-plugin-inline-package-json": "^1.0.1",
     "browserify": "^10.2.4",
     "codeclimate-test-reporter": "^0.1.1",
     "gulp": "^3.9.0",
     "gulp-bump": "^0.3.1",
+    "gulp-git": "^1.6.0",
     "gulp-gzip": "^1.1.0",
     "gulp-if": "^1.2.5",
     "gulp-istanbul": "^0.10.0",
@@ -45,6 +54,7 @@
     "gulp-mocha": "^2.1.2",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
+    "gulp-sequence": "^0.4.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",
     "istanbul": "^0.4.1",


### PR DESCRIPTION
After each merge to master CI will:
- add a `tag` with current version
- push `tag` to GitHub
- go to and fetch `devel` branch
- merge `master` to `devel`
- bump version, commit and push to GitHub (with CI build ignored)
