### PR TITLE
[LIB-472] Webpack build optimalizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "url": "https://github.com/Syncano/syncano-js.git"
   },
   "dependencies": {
+    "babel-plugin-lodash": "^2.2.1",
     "bluebird": "^3.2.2",
     "lodash": "^4.6.1",
     "stampit": "^2.1.1",
@@ -92,7 +93,8 @@
     "plugins": [
       "transform-inline-environment-variables",
       "transform-strict-mode",
-      "add-module-exports"
+      "add-module-exports",
+      "lodash"
     ],
     "presets": [
       "es2015"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "url": "https://github.com/Syncano/syncano-js.git"
   },
   "dependencies": {
-    "babel-plugin-lodash": "^2.2.1",
     "bluebird": "^3.2.2",
     "lodash": "^4.6.1",
     "stampit": "^2.1.1",
@@ -87,7 +86,8 @@
     "rimraf": "^2.5.1",
     "should": "^8.2.2",
     "sinon": "^1.17.3",
-    "webpack": "^1.12.13"
+    "webpack": "^1.12.13",
+    "babel-plugin-lodash": "^2.2.1"
   },
   "babel": {
     "plugins": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,9 @@ module.exports = [
           warnings: false,
           drop_console: true,
           drop_debugger: true
+        },
+        output: {
+          comments: false
         }
       })
     ]


### PR DESCRIPTION
I was able to strip ~40kb from the lib. It's not much, but I couldn't shrink it down more using just the configuration. The new lib is ~30kb bigger than the old one. I guess we could refactor some stuff if we want to save some more space.
