### PR TITLE
[LIB-652] Add support for dataobject filtering by geo fields

### DIFF
--- a/src/models/dataobject.js
+++ b/src/models/dataobject.js
@@ -65,6 +65,31 @@ const DataObjectQuerySet = stampit().compose(QuerySet).methods({
     return this;
   },
   /**
+    * Filters dataobjects by a geopoint field.
+
+    * @memberOf QuerySet
+    * @instance
+
+    * @param {Object} coordinates
+    * @returns {QuerySet}
+
+    * @example {@lang javascript}
+    * DataObject.please().list({ instanceName: 'test-instace', className: 'test-class' }).near({ geopoint_field_name: { latitude: POINT_LATITUDE, longitude: POINT_LONGITUDE }}).then(function(dataobjects) {});
+
+    * @example {@lang javascript}
+    * DataObject.please().list({ instanceName: 'test-instace', className: 'test-class' }).near({ geopoint_field_name: { latitude: POINT_LATITUDE, longitude: POINT_LONGITUDE, distance_in_kilometers: DISTANCE_IN_KILOMETERS }}).then(function(dataobjects) {});
+
+    * @example {@lang javascript}
+    * DataObject.please().list({ instanceName: 'test-instace', className: 'test-class' }).near({ geopoint_field_name: { latitude: POINT_LATITUDE, longitude: POINT_LONGITUDE, distance_in_miles: DISTANCE_IN_MILES }}).then(function(dataobjects) {});
+
+    */
+  near(object = {}) {
+    const query = {};
+    query[_.keys(object)[0]] = { _near: object[_.keys(object)[0]]};
+    this.query['query'] = JSON.stringify(query);
+    return this;
+  },
+  /**
     * Returns DataObject count.
 
     * @memberOf QuerySet

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -5,7 +5,7 @@ import Syncano from '../../src/syncano';
 import {ValidationError} from '../../src/errors';
 import {suffix, credentials, createCleaner} from './utils';
 
-describe('Dataobject', function() {
+describe.only('Dataobject', function() {
   this.timeout(15000);
 
   const cleaner = createCleaner();
@@ -39,7 +39,7 @@ describe('Dataobject', function() {
     description,
     schema: [
       { name: "location_name", type: "string" },
-      { name: "coordinates", type: "geopoint" }
+      { name: "coordinates", type: "geopoint", "filter_index": true }
     ]
   }
   const location1 = {
@@ -218,6 +218,42 @@ describe('Dataobject', function() {
       return Model.please().list({instanceName, className}).then((dataobjects) => {
         should(dataobjects).be.an.Array();
       });
+    });
+
+    it('should be able to list objects near coordinates', function() {
+      return Model.please().create(location1)
+        .then(cleaner.mark)
+        .then(() => {
+          return Model.please().list({instanceName, className: location1.className}).near({ coordinates: {latitude: 52.229676, longitude: 21.012229}});
+        })
+        .then((objects) => {
+          should(objects).be.an.Array().with.length(1);
+          should(objects[0].coordinates).have.property('latitude').which.is.Number().equal(location1.coordinates.latitude);   should(objects[0].coordinates).have.property('longitude').which.is.Number().equal(location1.coordinates.longitude);
+        })
+    });
+
+    it('should be able to list objects near coordinates within a distance in kilometers', function() {
+      return Model.please().create(location1)
+        .then(cleaner.mark)
+        .then(() => {
+          return Model.please().list({instanceName, className: location1.className}).near({ coordinates: {latitude: 51.865512, longitude: 20.866603, distance_in_kilometers: 50}});
+        })
+        .then((objects) => {
+          should(objects).be.an.Array().with.length(1);
+          should(objects[0].coordinates).have.property('latitude').which.is.Number().equal(location1.coordinates.latitude);   should(objects[0].coordinates).have.property('longitude').which.is.Number().equal(location1.coordinates.longitude);
+        })
+    });
+
+    it('should be able to list objects near coordinates within a distance in miles', function() {
+      return Model.please().create(location1)
+        .then(cleaner.mark)
+        .then(() => {
+          return Model.please().list({instanceName, className: location1.className}).near({ coordinates: {latitude: 51.982047, longitude: 20.521618, distance_in_miles: 31}});
+        })
+        .then((objects) => {
+          should(objects).be.an.Array().with.length(1);
+          should(objects[0].coordinates).have.property('latitude').which.is.Number().equal(location1.coordinates.latitude);   should(objects[0].coordinates).have.property('longitude').which.is.Number().equal(location1.coordinates.longitude);
+        })
     });
 
     it('should be able to create a Model', function() {

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -5,7 +5,7 @@ import Syncano from '../../src/syncano';
 import {ValidationError} from '../../src/errors';
 import {suffix, credentials, createCleaner} from './utils';
 
-describe.only('Dataobject', function() {
+describe('Dataobject', function() {
   this.timeout(15000);
 
   const cleaner = createCleaner();


### PR DESCRIPTION
DataObjects now have a `near()` helper method for querying with geofields. You can use it like this:

```
DataObject.please()
  .list({ instanceName: 'test-instace', className: 'test-class' })
  .near({ geopoint_field_name: { latitude: POINT_LATITUDE, longitude: POINT_LONGITUDE }})
  .then(function(dataobjects) {});
```

```
DataObject.please()
  .list({ instanceName: 'test-instace', className: 'test-class' })
  .near({ geopoint_field_name: { latitude: POINT_LATITUDE, longitude: POINT_LONGITUDE, distance_in_kilometers: DISTANCE_IN_KILOMETERS }})
  .then(function(dataobjects) {});
```

```
DataObject.please()
  .list({ instanceName: 'test-instace', className: 'test-class' })
  .near({ geopoint_field_name: { latitude: POINT_LATITUDE, longitude: POINT_LONGITUDE, distance_in_miles: DISTANCE_IN_MILES }})
  .then(function(dataobjects) {});
```
