### PR TITLE
[LIB-708] Relation fields support + filtering

### DIFF
--- a/src/models/dataobject.js
+++ b/src/models/dataobject.js
@@ -41,7 +41,55 @@ const DataObjectQuerySet = stampit().compose(QuerySet).methods({
     return this;
   },
   /**
-  * Updates single object based on provided arguments
+  * Adds an array to an array field.
+
+  * @memberOf QuerySet
+  * @instance
+
+  * @param {Object} properties lookup properties used for path resolving
+  * @param {Object} field to add to.
+  * @returns {QuerySet}
+
+  * @example {@lang javascript}
+  * DataObject.please().add({instanceName: 'my-instance', className: 'my-class', id: 1}, {array_field: [1,2]})
+
+  */
+  add(properties = {}, object = {}) {
+    const payload = {};
+    payload[_.keys(object)[0]] = { _add: object[_.keys(object)[0]] };
+    this.properties = _.assign({}, this.properties, properties);
+    this.payload = JSON.stringify(payload);
+
+    this.method = 'PATCH';
+    this.endpoint = 'detail';
+    return this;
+  },
+  /**
+  * Subtracts an array from an array field.
+
+  * @memberOf QuerySet
+  * @instance
+
+  * @param {Object} properties lookup properties used for path resolving
+  * @param {Object} field to subtract from.
+  * @returns {QuerySet}
+
+  * @example {@lang javascript}
+  * DataObject.please().remove({instanceName: 'my-instance', className: 'my-class', id: 1}, {array_field: [1,2]})
+
+  */
+  remove(properties = {}, object = {}) {
+    const payload = {};
+    payload[_.keys(object)[0]] = { _remove: object[_.keys(object)[0]] };
+    this.properties = _.assign({}, this.properties, properties);
+    this.payload = JSON.stringify(payload);
+
+    this.method = 'PATCH';
+    this.endpoint = 'detail';
+    return this;
+  },
+  /**
+  * Increments single object based on provided arguments
 
   * @memberOf QuerySet
   * @instance
@@ -184,6 +232,20 @@ const DataObject = stampit()
   .compose(Model)
   .setMeta(DataObjectMeta)
   .methods({
+    /**
+    * Increments single object field based on provided arguments
+
+    * @memberOf QuerySet
+    * @instance
+
+    * @param {String} field name.
+    * @param {Number} value to increment the field by,
+    * @returns {QuerySet}
+
+    * @example {@lang javascript}
+    * Object.increment('views', 1);
+
+    */
     increment(field, by) {
       if(!_.isNumber(this[field])) return Promise.reject(new Error(`The ${field} is not numeric.`));
       if(!_.isNumber(by)) return Promise.reject(new Error('The provided value is not numeric.'));
@@ -192,7 +254,20 @@ const DataObject = stampit()
 
       return this.save();
     },
+    /**
+    * Adds an array to an array field.
 
+    * @memberOf QuerySet
+    * @instance
+
+    * @param {String} field name.
+    * @param {Array} array to add to the field.
+    * @returns {QuerySet}
+
+    * @example {@lang javascript}
+    * Object.add('authors', [1,2,3]);
+
+    */
     add(field, array) {
       if(!_.isArray(this[field].value)) return Promise.reject(new Error(`The ${field} is not an array.`));
       if(!_.isArray(array)) return Promise.reject(new Error('The provided value is not an array.'));
@@ -201,7 +276,20 @@ const DataObject = stampit()
 
       return this.save();
     },
+    /**
+    * Subtracts an array from an array field.
 
+    * @memberOf QuerySet
+    * @instance
+
+    * @param {String} field name.
+    * @param {Array} array to subtract from the field.
+    * @returns {QuerySet}
+
+    * @example {@lang javascript}
+    * Object.remove('authors', [1]);
+
+    */
     remove(field, array) {
       if(!_.isArray(this[field].value)) return Promise.reject(new Error(`The ${field} is not an array.`));
       if(!_.isArray(array)) return Promise.reject(new Error('The provided value is not an array.'));

--- a/src/models/dataobject.js
+++ b/src/models/dataobject.js
@@ -65,6 +65,30 @@ const DataObjectQuerySet = stampit().compose(QuerySet).methods({
     return this;
   },
   /**
+  * Adds an array to an array field without duplicate values.
+
+  * @memberOf QuerySet
+  * @instance
+
+  * @param {Object} properties lookup properties used for path resolving
+  * @param {Object} field to add to.
+  * @returns {QuerySet}
+
+  * @example {@lang javascript}
+  * DataObject.please().add({instanceName: 'my-instance', className: 'my-class', id: 1}, {array_field: [1,2]})
+
+  */
+  addUnique(properties = {}, object = {}) {
+    const payload = {};
+    payload[_.keys(object)[0]] = { _addunique: object[_.keys(object)[0]] };
+    this.properties = _.assign({}, this.properties, properties);
+    this.payload = JSON.stringify(payload);
+
+    this.method = 'PATCH';
+    this.endpoint = 'detail';
+    return this;
+  },
+  /**
     * Filters DataObjects using _is.
 
     * @memberOf QuerySet
@@ -311,6 +335,28 @@ const DataObject = stampit()
       if(!_.isArray(array)) return Promise.reject(new Error('The provided value is not an array.'));
 
       this[field] = _.concat(this[field].value, array);
+
+      return this.save();
+    },
+    /**
+    * Adds an array to an array field without duplicate values.
+
+    * @memberOf QuerySet
+    * @instance
+
+    * @param {String} field name.
+    * @param {Array} array to add to the field.
+    * @returns {QuerySet}
+
+    * @example {@lang javascript}
+    * Object.add('authors', [1,2,3]);
+
+    */
+    addUnique(field, array) {
+      if(!_.isArray(this[field].value)) return Promise.reject(new Error(`The ${field} is not an array.`));
+      if(!_.isArray(array)) return Promise.reject(new Error('The provided value is not an array.'));
+
+      this[field] = _.union(this[field].value, array);
 
       return this.save();
     },

--- a/src/models/dataobject.js
+++ b/src/models/dataobject.js
@@ -65,6 +65,44 @@ const DataObjectQuerySet = stampit().compose(QuerySet).methods({
     return this;
   },
   /**
+    * Filters DataObjects using _is.
+
+    * @memberOf QuerySet
+    * @instance
+
+    * @param {String} field name
+    * @param {Object} filters
+    * @returns {QuerySet}
+
+    * @example {@lang javascript}
+    * DataObject.please().list({instanceName: 'my-instance', className: 'books'}).is('authors', { name: { _eq: 'Stephen King'}})
+
+    */
+  is(field, object = {}) {
+    const query = {};
+    query[field] = { _is: object};
+    return this.filter(query);
+  },
+  /**
+    * Filters DataObjects using _contains.
+
+    * @memberOf QuerySet
+    * @instance
+
+    * @param {String} field name
+    * @param {Array} array of ids
+    * @returns {QuerySet}
+
+    * @example {@lang javascript}
+    * DataObject.please().list({instanceName: 'my-instance', className: 'books'}).contains('authors', [1, 2, 3])
+
+    */
+  contains(field, array = []) {
+    const query = {};
+    query[field] = { _contains: array};
+    return this.filter(query);
+  },
+  /**
   * Subtracts an array from an array field.
 
   * @memberOf QuerySet

--- a/src/models/dataobject.js
+++ b/src/models/dataobject.js
@@ -192,6 +192,24 @@ const DataObject = stampit()
       this[field] += _.add(this[field], by);
 
       return this.save();
+    },
+
+    add(field, array) {
+      if(!_.isArray(this[field].value)) return Promise.reject(new Error(`The ${field} is not an array.`));
+      if(!_.isArray(array)) return Promise.reject(new Error('The provided value is not an array.'));
+
+      this[field] = _.concat(this[field].value, array);
+
+      return this.save();
+    },
+
+    remove(field, array) {
+      if(!_.isArray(this[field].value)) return Promise.reject(new Error(`The ${field} is not an array.`));
+      if(!_.isArray(array)) return Promise.reject(new Error('The provided value is not an array.'));
+
+      this[field] = _.difference(this[field].value, array);
+
+      return this.save();
     }
   })
   .setQuerySet(DataObjectQuerySet)

--- a/src/models/dataobject.js
+++ b/src/models/dataobject.js
@@ -86,8 +86,7 @@ const DataObjectQuerySet = stampit().compose(QuerySet).methods({
   near(object = {}) {
     const query = {};
     query[_.keys(object)[0]] = { _near: object[_.keys(object)[0]]};
-    this.query['query'] = JSON.stringify(query);
-    return this;
+    return this.filter(query);
   },
   /**
     * Returns DataObject count.

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -46,8 +46,8 @@ describe('Dataobject', function() {
     name: 'books',
     instanceName,
     schema: [
-      { name: 'title', type: 'string', filter_index: true },
-      { name: 'authors', type: 'relation', target: 'authors'}
+      { name: 'title', type: 'string'},
+      { name: 'authors', type: 'relation', target: 'authors', filter_index: true }
     ]
   };
   const authorsClass = {
@@ -403,6 +403,78 @@ describe('Dataobject', function() {
           should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
           should(book.authors.value[1]).be.a.Number().equal(authorIds[1]);
         });
+    });
+
+    it('should be able to filter objects by relation using #is()', function() {
+      let authorIds = null;
+      const books = [
+        Model({instanceName, className: 'books', title: 'Ubik'}),
+        Model({instanceName, className: 'books', title: 'Man in the high castle'})
+      ]
+
+      return Model.please().bulkCreate([Model(philipKDick), Model(charlesBukowski)])
+        .then(cleaner.mark)
+        .then((authors) => {
+          should(authors).be.an.Array().with.length(2);
+
+          authorIds = _.map(authors, (x) => x.id);
+
+          books[0].authors = [authorIds[0]];
+
+          return Model.please().bulkCreate(books);
+        })
+        .then(cleaner.mark)
+        .then(() => {
+
+          return Model.please().list({instanceName, className: 'books'}).is('authors', { name: { _eq: 'Philip K Dick'}})
+        })
+        .then((books) => {
+          should(books).be.an.Array().with.length(1);
+          should(books[0]).be.an.Object();
+          should(books[0]).have.property('instanceName').which.is.String().equal(instanceName);
+          should(books[0]).have.property('className').which.is.String().equal('books');
+          should(books[0]).have.property('title').which.is.String().equal('Ubik');
+          should(books[0]).have.property('authors').which.is.Object();
+          should(books[0].authors).have.property('target').which.is.String().equal('authors');
+          should(books[0].authors).have.property('value').which.is.Array().with.length(1);
+          should(books[0].authors.value[0]).be.a.Number().equal(authorIds[0]);
+        })
+    });
+
+    it('should be able to filter objects by relation using #contains()', function() {
+      let authorIds = null;
+      const books = [
+        Model({instanceName, className: 'books', title: 'Ubik'}),
+        Model({instanceName, className: 'books', title: 'Valis'})
+      ]
+
+      return Model.please().bulkCreate([Model(philipKDick), Model(charlesBukowski)])
+        .then(cleaner.mark)
+        .then((authors) => {
+          should(authors).be.an.Array().with.length(2);
+
+          authorIds = _.map(authors, (x) => x.id);
+
+          books[1].authors = [authorIds[1]];
+
+          return Model.please().bulkCreate(books);
+        })
+        .then(cleaner.mark)
+        .then(() => {
+
+          return Model.please().list({instanceName, className: 'books'}).contains('authors', [authorIds[1]])
+        })
+        .then((books) => {
+          should(books).be.an.Array().with.length(1);
+          should(books[0]).be.an.Object();
+          should(books[0]).have.property('instanceName').which.is.String().equal(instanceName);
+          should(books[0]).have.property('className').which.is.String().equal('books');
+          should(books[0]).have.property('title').which.is.String().equal('Valis');
+          should(books[0]).have.property('authors').which.is.Object();
+          should(books[0].authors).have.property('target').which.is.String().equal('authors');
+          should(books[0].authors).have.property('value').which.is.Array().with.length(1);
+          should(books[0].authors.value[0]).be.a.Number().equal(authorIds[1]);
+        })
     });
 
     it('should be able to remove relation', function() {

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -263,6 +263,39 @@ describe('Dataobject', function() {
       })
   });
 
+  it('should be able to add unique relations via model instance', function() {
+    let authorIds = null;
+
+    return Model.please().bulkCreate([Model(philipKDick), Model(charlesBukowski)])
+      .then(cleaner.mark)
+      .then((authors) => {
+        should(authors).be.an.Array().with.length(2);
+
+        authorIds = _.map(authors, (x) => x.id)
+
+        return Model({instanceName, className: 'books', title: 'Ubik', authors: [authorIds[0]]}).save();
+      })
+      .then(cleaner.mark)
+      .then((book) => {
+        should(book).be.an.Object();
+        should(book).have.property('instanceName').which.is.String().equal(instanceName);
+        should(book).have.property('className').which.is.String().equal('books');
+        should(book).have.property('title').which.is.String().equal('Ubik');
+        should(book).have.property('authors').which.is.Object();
+        should(book.authors).have.property('target').which.is.String().equal('authors');
+        should(book.authors).have.property('value').which.is.Array().with.length(1);
+        should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
+
+        return book.addUnique('authors', authorIds);
+      })
+      .then((book) => {
+        should(book.authors).have.property('target').which.is.String().equal('authors');
+        should(book.authors).have.property('value').which.is.Array().with.length(2);
+        should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
+        should(book.authors.value[1]).be.a.Number().equal(authorIds[1]);
+      })
+  });
+
   it('should be able to remove relation via model instance', function() {
     let authorIds = null;
 
@@ -403,6 +436,39 @@ describe('Dataobject', function() {
           should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
           should(book.authors.value[1]).be.a.Number().equal(authorIds[1]);
         });
+    });
+
+    xit('should be able to add unique relations', function() {
+      let authorIds = null;
+
+      return Model.please().bulkCreate([Model(philipKDick), Model(charlesBukowski)])
+        .then(cleaner.mark)
+        .then((authors) => {
+          should(authors).be.an.Array().with.length(2);
+
+          authorIds = _.map(authors, (x) => x.id)
+
+          return Model.please().create({instanceName, className: 'books', title: 'Ubik', authors: [authorIds[0]]});
+        })
+        .then(cleaner.mark)
+        .then((book) => {
+          should(book).be.an.Object();
+          should(book).have.property('instanceName').which.is.String().equal(instanceName);
+          should(book).have.property('className').which.is.String().equal('books');
+          should(book).have.property('title').which.is.String().equal('Ubik');
+          should(book).have.property('authors').which.is.Object();
+          should(book.authors).have.property('target').which.is.String().equal('authors');
+          should(book.authors).have.property('value').which.is.Array().with.length(1);
+          should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
+
+          return Model.please().addUnique({id: book.id, instanceName, className: 'books'}, { authors: authorIds });
+        })
+        .then((book) => {
+          should(book.authors).have.property('target').which.is.String().equal('authors');
+          should(book.authors).have.property('value').which.is.Array().with.length(2);
+          should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
+          should(book.authors.value[1]).be.a.Number().equal(authorIds[1]);
+        })
     });
 
     it('should be able to filter objects by relation using #is()', function() {

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -438,39 +438,6 @@ describe('Dataobject', function() {
         });
     });
 
-    xit('should be able to add unique relations', function() {
-      let authorIds = null;
-
-      return Model.please().bulkCreate([Model(philipKDick), Model(charlesBukowski)])
-        .then(cleaner.mark)
-        .then((authors) => {
-          should(authors).be.an.Array().with.length(2);
-
-          authorIds = _.map(authors, (x) => x.id)
-
-          return Model.please().create({instanceName, className: 'books', title: 'Ubik', authors: [authorIds[0]]});
-        })
-        .then(cleaner.mark)
-        .then((book) => {
-          should(book).be.an.Object();
-          should(book).have.property('instanceName').which.is.String().equal(instanceName);
-          should(book).have.property('className').which.is.String().equal('books');
-          should(book).have.property('title').which.is.String().equal('Ubik');
-          should(book).have.property('authors').which.is.Object();
-          should(book.authors).have.property('target').which.is.String().equal('authors');
-          should(book.authors).have.property('value').which.is.Array().with.length(1);
-          should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
-
-          return Model.please().addUnique({id: book.id, instanceName, className: 'books'}, { authors: authorIds });
-        })
-        .then((book) => {
-          should(book.authors).have.property('target').which.is.String().equal('authors');
-          should(book.authors).have.property('value').which.is.Array().with.length(2);
-          should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
-          should(book.authors.value[1]).be.a.Number().equal(authorIds[1]);
-        })
-    });
-
     it('should be able to filter objects by relation using #is()', function() {
       let authorIds = null;
       const books = [


### PR DESCRIPTION
The `relation` field type is supported in the DataObject schema:

```
 schema: [
   { name: 'title', type: 'string' },
   { name: 'authors', type: 'relation', target: 'authors', filter_index: true }
 ]
```

So you would save an object like so:

```
DataObject({instanceName, className, title: 'Ubik', authors: [1]}).save();
```

Or via querySet:

```
DataObject.please().create({instanceName, className, title: 'Ubik', authors: [1]});
```

Relations can be added:

```
DataObject.please().add({id: book.id, instanceName, className}, { authors: [2]});
```

And removed:

```
DataObject.please().remove({id: book.id, instanceName, className}, { authors: [2]});
```

Filtering is also supported.

IS:

```
DataObject.please().list({instanceName, className}).is('authors', { name: { _eq: 'Philip K Dick'}})
```

CONTAINS:

```
DataObject.please().list({instanceName, className}).contains('authors', [2])
```
