### PR TITLE
[LIB-568] Support for cache_key

### DIFF
--- a/src/models/dataendpoint.js
+++ b/src/models/dataendpoint.js
@@ -12,17 +12,14 @@ const DataEndpointQerySet = stampit().compose(QuerySet).methods({
   * @instance
 
   * @param {Object} properties lookup properties used for path resolving
-  * @param {String} cache_key the cache key for the result
   * @returns {DataEndpointQerySet}
 
   * @example {@lang javascript}
   * DataEndpoint.please().fetchData({name: 'dataViewName', instanceName: 'test-one'}).then(function(dataObjects) {});
 
   */
-  fetchData(properties = {}, cache_key) {
+  fetchData(properties = {}) {
     this.properties = _.assign({}, this.properties, properties);
-
-    if(!_.isEmpty(cache_key)) this.query['cache_key'] = cache_key;
 
     this.method = 'GET';
     this.endpoint = 'get';

--- a/src/models/dataendpoint.js
+++ b/src/models/dataendpoint.js
@@ -12,14 +12,17 @@ const DataEndpointQerySet = stampit().compose(QuerySet).methods({
   * @instance
 
   * @param {Object} properties lookup properties used for path resolving
+  * @param {String} cache_key the cache key for the result
   * @returns {DataEndpointQerySet}
 
   * @example {@lang javascript}
   * DataEndpoint.please().fetchData({name: 'dataViewName', instanceName: 'test-one'}).then(function(dataObjects) {});
 
   */
-  fetchData(properties = {}) {
+  fetchData(properties = {}, cache_key) {
     this.properties = _.assign({}, this.properties, properties);
+
+    if(!_.isEmpty(cache_key)) this.query['cache_key'] = cache_key;
 
     this.method = 'GET';
     this.endpoint = 'get';
@@ -123,17 +126,20 @@ const DataEndpoint = stampit()
     * @memberOf DataEndpoint
     * @instance
 
-    * @param {Object}
+    * @param {String} cache_key the cache key for the result
     * @returns {Promise}
 
     * @example {@lang javascript}
     * DataEndpoint.please().fetchData({name: 'dataViewName', instanceName: 'test-one'}).then(function(dataObjects) {});
     */
-    fetchData() {
+    fetchData(cache_key) {
       const meta = this.getMeta();
       const path = meta.resolveEndpointPath('get', this);
 
-      return this.makeRequest('GET', path);
+      const query = {};
+      if(!_.isEmpty(cache_key)) query.cache_key = cache_key;
+
+      return this.makeRequest('GET', path, {query});
     }
 
   });

--- a/src/models/scriptendpoint.js
+++ b/src/models/scriptendpoint.js
@@ -13,17 +13,14 @@ const ScriptEndpointQuerySet = stampit().compose(QuerySet).methods({
 
   * @param {Object} properties lookup properties used for path resolving
   * @param {Object} payload the payload to be sent
-  * @param {String}  cache_key the cache key for the result
   * @returns {Promise}
 
   * @example {@lang javascript}
   * ScriptEndpoint.please().run({name: 'test', instanceName: 'test-one'}).then(function(trace) {});
 
   */
-  run(properties = {}, payload = {}, cache_key) {
+  run(properties = {}, payload = {}) {
     const {ScriptEndpointTrace} = this.getConfig();
-
-    if(!_.isEmpty(cache_key)) this.query['cache_key'] = cache_key;
 
     this.properties = _.assign({}, this.properties, properties);
     this.method = 'POST';
@@ -46,17 +43,14 @@ const ScriptEndpointQuerySet = stampit().compose(QuerySet).methods({
 
   * @param {Object} properties lookup properties used for path resolving
   * @param {Object} payload the payload to be sent
-  * @param {String}  cache_key the cache key for the result
   * @returns {Promise}
 
   * @example {@lang javascript}
   * ScriptEndpoint.please().runPublic({public_link: '44cfc5552eacc', instanceName: 'test-one'}).then(function(trace) {});
 
   */
-  runPublic(properties = {}, payload = {}, cache_key) {
+  runPublic(properties = {}, payload = {}) {
     const {ScriptEndpointTrace} = this.getConfig();
-
-    if(!_.isEmpty(cache_key)) this.query['cache_key'] = cache_key;
 
     this.properties = _.assign({}, this.properties, properties);
     this.method = 'POST';

--- a/src/models/scriptendpoint.js
+++ b/src/models/scriptendpoint.js
@@ -12,14 +12,18 @@ const ScriptEndpointQuerySet = stampit().compose(QuerySet).methods({
   * @instance
 
   * @param {Object} properties lookup properties used for path resolving
+  * @param {Object} payload the payload to be sent
+  * @param {String}  cache_key the cache key for the result
   * @returns {Promise}
 
   * @example {@lang javascript}
   * ScriptEndpoint.please().run({name: 'test', instanceName: 'test-one'}).then(function(trace) {});
 
   */
-  run(properties = {}, payload = {}) {
+  run(properties = {}, payload = {}, cache_key) {
     const {ScriptEndpointTrace} = this.getConfig();
+
+    if(!_.isEmpty(cache_key)) this.query['cache_key'] = cache_key;
 
     this.properties = _.assign({}, this.properties, properties);
     this.method = 'POST';
@@ -41,14 +45,18 @@ const ScriptEndpointQuerySet = stampit().compose(QuerySet).methods({
   * @instance
 
   * @param {Object} properties lookup properties used for path resolving
+  * @param {Object} payload the payload to be sent
+  * @param {String}  cache_key the cache key for the result
   * @returns {Promise}
 
   * @example {@lang javascript}
   * ScriptEndpoint.please().runPublic({public_link: '44cfc5552eacc', instanceName: 'test-one'}).then(function(trace) {});
 
   */
-  runPublic(properties = {}, payload = {}) {
+  runPublic(properties = {}, payload = {}, cache_key) {
     const {ScriptEndpointTrace} = this.getConfig();
+
+    if(!_.isEmpty(cache_key)) this.query['cache_key'] = cache_key;
 
     this.properties = _.assign({}, this.properties, properties);
     this.method = 'POST';
@@ -174,10 +182,12 @@ const ScriptEndpoint = stampit()
         codebox.run({some: 'variable'}).then(function(trace) {});
       });
     */
-    run(payload = {}) {
+    run(payload = {}, cache_key) {
       const {ScriptEndpointTrace} = this.getConfig();
       const meta = this.getMeta();
       const path = meta.resolveEndpointPath('run', this);
+
+      if(!_.isEmpty(cache_key)) _.assign(payload, { query: {cache_key} })
 
       return this.makeRequest('POST', path, {payload})
         .then((body) => {
@@ -201,12 +211,14 @@ const ScriptEndpoint = stampit()
         codebox.runPublic({some: 'variable'}).then(function(trace) {});
       });
     */
-    runPublic(payload = {}) {
+    runPublic(payload = {}, cache_key) {
       const {ScriptEndpointTrace} = this.getConfig();
       const meta = this.getMeta();
       const path = meta.resolveEndpointPath('public', this);
 
-      return this.makeRequest('POST', path, {payload})
+      if(!_.isEmpty(cache_key)) _.assign(payload, { query: {cache_key} })
+
+      return this.makeRequest('POST', path, {payload}, cache_key)
         .then((body) => {
           return ScriptEndpointTrace.fromJSON(body, {
             instanceName: this.instanceName,

--- a/src/querySet.js
+++ b/src/querySet.js
@@ -260,7 +260,7 @@ const CacheKey = stampit().methods({
 
   cacheKey(cache_key) {
     this.query['cache_key'] = cache_key;
-    return this
+    return this;
   }
 });
 

--- a/src/querySet.js
+++ b/src/querySet.js
@@ -244,6 +244,26 @@ export const Create = stampit().methods({
   }
 });
 
+const CacheKey = stampit().methods({
+  /**
+  * Sets the provided cache key in the request query.
+  * @memberOf QuerySet
+  * @instance
+
+  * @param {String} cache_key the cache key for the result
+  * @returns {QuerySet}
+
+  * @example {@lang javascript}
+  * DataEndpoint.please().DataEndpoint.please().fetchData({name: 'dataViewName', instanceName: 'test-one'}).cacheKey('123').then(function(data) {});
+
+  */
+
+  cacheKey(cache_key) {
+    this.query['cache_key'] = cache_key;
+    return this
+  }
+});
+
 export const Get = stampit().methods({
 
   /**
@@ -768,7 +788,8 @@ export const BaseQuerySet = stampit.compose(
   Ordering,
   First,
   PageSize,
-  TemplateResponse
+  TemplateResponse,
+  CacheKey
 );
 
 export default QuerySet;

--- a/src/querySet.js
+++ b/src/querySet.js
@@ -777,7 +777,8 @@ const QuerySet = stampit.compose(
   Fields,
   ExcludedFields,
   Raw,
-  TemplateResponse
+  TemplateResponse,
+  CacheKey
 );
 
 export const BaseQuerySet = stampit.compose(
@@ -788,8 +789,7 @@ export const BaseQuerySet = stampit.compose(
   Ordering,
   First,
   PageSize,
-  TemplateResponse,
-  CacheKey
+  TemplateResponse
 );
 
 export default QuerySet;

--- a/test/integration/dataEndpointsTest.js
+++ b/test/integration/dataEndpointsTest.js
@@ -98,33 +98,6 @@ describe('DataEndpoint', function() {
     should(Model({name: dataEndpointName, instanceName, expand: 1337}).save()).be.rejectedWith(/expand/);
   });
 
-  it('should be able to fetch Data Objects', function() {
-
-    return Promise
-      .mapSeries(_.range(10), (int) => dataObject({className, instanceName, int}).save())
-      .then(cleaner.mark)
-      .then(() => {
-        return Model.please().create(data)
-      })
-      .then(cleaner.mark)
-      .then((dta) => {
-        should(dta).be.an.Object();
-      })
-      .then(() => {
-          return Model
-            .please()
-            .fetchData({name: dataEndpointName, instanceName})
-            .request();
-        })
-      .then(([data, response]) => {
-        should(response).be.an.Object();
-        should(data).be.an.Object();
-        should(data).have.property('objects').which.is.Array();
-        should(data.objects[0]).have.property('int').which.is.Number().equal(9);
-        should(data.objects.length).equal(5);
-      });
-  });
-
   it('should be able to save via model instance', function() {
     return Model(data).save()
       .then(cleaner.mark)
@@ -140,6 +113,46 @@ describe('DataEndpoint', function() {
         should(dta).have.property('expand').which.is.Null();
         should(dta).have.property('links').which.is.Object();
         should(dta).have.property('class').which.is.String().equal(data.class)
+      });
+  });
+
+  it('should be able to fetch DataObjects via model instance', function() {
+    return Promise
+      .mapSeries(_.range(10), (int) => dataObject({className, instanceName, int}).save())
+      .then(cleaner.mark)
+      .then(() => {
+        return Model(data).save();
+      })
+      .then(cleaner.mark)
+      .then((dta) => {
+        should(dta).be.an.Object();
+        return dta.fetchData();
+      })
+      .then((data) => {
+        should(data).be.an.Object();
+        should(data).have.property('objects').which.is.Array();
+        should(data.objects[0]).have.property('int').which.is.Number().equal(9);
+        should(data.objects.length).equal(5);
+      });
+  });
+
+  it('should be able to fetch DataObjects via model instance with cache_key', function() {
+    return Promise
+      .mapSeries(_.range(10), (int) => dataObject({className, instanceName, int}).save())
+      .then(cleaner.mark)
+      .then(() => {
+        return Model(data).save();
+      })
+      .then(cleaner.mark)
+      .then((dta) => {
+        should(dta).be.an.Object();
+        return dta.fetchData('123');
+      })
+      .then((data) => {
+        should(data).be.an.Object();
+        should(data).have.property('objects').which.is.Array();
+        should(data.objects[0]).have.property('int').which.is.Number().equal(9);
+        should(data.objects.length).equal(5);
       });
   });
 
@@ -198,7 +211,7 @@ describe('DataEndpoint', function() {
         });
     });
 
-    it('should be able to bulk create an objects', function() {
+    it('should be able to bulk create objects', function() {
       const objects = [
         Model(data),
         Model(_.assign({}, data, {name: `${dataEndpointName}1`}))
@@ -211,7 +224,7 @@ describe('DataEndpoint', function() {
         });
     });
 
-    it('should be able to get a Model', function() {
+    it('should be able to get model', function() {
       return Model.please().create(data)
         .then(cleaner.mark)
         .then((dta) => {
@@ -240,6 +253,62 @@ describe('DataEndpoint', function() {
           should(dta).have.property('expand').which.is.Null();
           should(dta).have.property('links').which.is.Object();
           should(dta).have.property('class').which.is.String().equal(data.class)
+        });
+    });
+
+    it('should be able to fetch DataObjects', function() {
+      return Promise
+        .mapSeries(_.range(10), (int) => dataObject({className, instanceName, int}).save())
+        .then(cleaner.mark)
+        .then(() => {
+            return Model.please().create(data)
+        })
+        .then(cleaner.mark)
+        .then((dta) => {
+          should(dta).be.a.Object();
+          should(dta).have.property('name').which.is.String().equal(dataEndpointName);
+          should(dta).have.property('instanceName').which.is.String().equal(instanceName);
+
+          return dta;
+        })
+        .then(() => {
+          return Model
+            .please()
+            .fetchData({name: dataEndpointName, instanceName})
+        })
+        .then((data) => {
+          should(data).be.an.Object();
+          should(data).have.property('objects').which.is.Array();
+          should(data.objects[0]).have.property('int').which.is.Number().equal(9);
+          should(data.objects.length).equal(5);
+        });
+    });
+
+    it('should be able to fetch DataObjects with cache key', function() {
+      return Promise
+        .mapSeries(_.range(10), (int) => dataObject({className, instanceName, int}).save())
+        .then(cleaner.mark)
+        .then(() => {
+            return Model.please().create(data)
+        })
+        .then(cleaner.mark)
+        .then((dta) => {
+          should(dta).be.a.Object();
+          should(dta).have.property('name').which.is.String().equal(dataEndpointName);
+          should(dta).have.property('instanceName').which.is.String().equal(instanceName);
+
+          return dta;
+        })
+        .then(() => {
+          return Model
+            .please()
+            .fetchData({name: dataEndpointName, instanceName}, '123')
+        })
+        .then((data) => {
+          should(data).be.an.Object();
+          should(data).have.property('objects').which.is.Array();
+          should(data.objects[0]).have.property('int').which.is.Number().equal(9);
+          should(data.objects.length).equal(5);
         });
     });
 

--- a/test/integration/dataEndpointsTest.js
+++ b/test/integration/dataEndpointsTest.js
@@ -302,7 +302,8 @@ describe('DataEndpoint', function() {
         .then(() => {
           return Model
             .please()
-            .fetchData({name: dataEndpointName, instanceName}).cacheKey('123')
+            .fetchData({name: dataEndpointName, instanceName})
+            .cacheKey('123')
         })
         .then((data) => {
           should(data).be.an.Object();

--- a/test/integration/dataEndpointsTest.js
+++ b/test/integration/dataEndpointsTest.js
@@ -284,7 +284,7 @@ describe('DataEndpoint', function() {
         });
     });
 
-    it('should be able to fetch DataObjects with cache key', function() {
+    it('should be able to fetch DataObjects with cache_key', function() {
       return Promise
         .mapSeries(_.range(10), (int) => dataObject({className, instanceName, int}).save())
         .then(cleaner.mark)
@@ -302,7 +302,7 @@ describe('DataEndpoint', function() {
         .then(() => {
           return Model
             .please()
-            .fetchData({name: dataEndpointName, instanceName}, '123')
+            .fetchData({name: dataEndpointName, instanceName}).cacheKey('123')
         })
         .then((data) => {
           should(data).be.an.Object();

--- a/test/integration/scriptEndpointsTest.js
+++ b/test/integration/scriptEndpointsTest.js
@@ -499,7 +499,7 @@ describe('ScriptEndpoint', function() {
           should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
           should(scriptendpoint).have.property('links').which.is.Object();
 
-          return Model.please().run(scriptendpoint, {}, '123');
+          return Model.please().run(scriptendpoint).cacheKey('123');
         }).then((trace) => {
           should(trace).be.a.Object();
           should(trace).have.property('id').which.is.Number();
@@ -544,7 +544,7 @@ describe('ScriptEndpoint', function() {
         should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
         should(scriptendpoint).have.property('links').which.is.Object();
 
-        return Model.please().runPublic(scriptendpoint, {}, '123');
+        return Model.please().runPublic(scriptendpoint).cacheKey('123');
       }).then((trace) => {
         should(trace).be.a.Object();
         should(trace).have.property('id').which.is.Number();

--- a/test/integration/scriptEndpointsTest.js
+++ b/test/integration/scriptEndpointsTest.js
@@ -499,7 +499,7 @@ describe('ScriptEndpoint', function() {
           should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
           should(scriptendpoint).have.property('links').which.is.Object();
 
-          return Model.please().run(scriptendpoint).cacheKey('123');
+          return Model.please().cacheKey('123').run(scriptendpoint);
         }).then((trace) => {
           should(trace).be.a.Object();
           should(trace).have.property('id').which.is.Number();
@@ -544,7 +544,7 @@ describe('ScriptEndpoint', function() {
         should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
         should(scriptendpoint).have.property('links').which.is.Object();
 
-        return Model.please().runPublic(scriptendpoint).cacheKey('123');
+        return Model.please().cacheKey('123').runPublic(scriptendpoint);
       }).then((trace) => {
         should(trace).be.a.Object();
         should(trace).have.property('id').which.is.Number();

--- a/test/integration/scriptEndpointsTest.js
+++ b/test/integration/scriptEndpointsTest.js
@@ -153,6 +153,28 @@ describe('ScriptEndpoint', function() {
       });
   });
 
+  it('should be able to run script via model instance with cacke_key', function() {
+    return Model(ModelData).save()
+      .then(cleaner.mark)
+      .then((scriptendpoint) => {
+        should(scriptendpoint).be.a.Object();
+        should(scriptendpoint).have.property('name').which.is.String().equal(ModelData.name);
+        should(scriptendpoint).have.property('instanceName').which.is.String().equal(ModelData.instanceName);
+        should(scriptendpoint).have.property('description').which.is.String().equal(ModelData.description);
+        should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
+        should(scriptendpoint).have.property('links').which.is.Object();
+
+        return scriptendpoint.run({}, '123');
+      }).then((trace) => {
+        should(trace).be.a.Object();
+        should(trace).have.property('id').which.is.Number();
+        should(trace).have.property('status').which.is.String();
+        should(trace).have.property('duration').which.is.Number();
+        should(trace).have.property('result').which.is.Object();
+        should(trace).have.property('executed_at').which.is.Date();
+      });
+  });
+
   it('should be able to run *public* script via model instance', function() {
     return Model(ModelData).save()
       .then(cleaner.mark)
@@ -165,6 +187,28 @@ describe('ScriptEndpoint', function() {
         should(scriptendpoint).have.property('links').which.is.Object();
 
         return scriptendpoint.runPublic();
+      }).then((trace) => {
+        should(trace).be.a.Object();
+        should(trace).have.property('id').which.is.Number();
+        should(trace).have.property('status').which.is.String();
+        should(trace).have.property('duration').which.is.Number();
+        should(trace).have.property('result').which.is.Object();
+        should(trace).have.property('executed_at').which.is.Date();
+      });
+  });
+
+  it('should be able to run *public* script via model instance with cache_key', function() {
+    return Model(ModelData).save()
+      .then(cleaner.mark)
+      .then((scriptendpoint) => {
+        should(scriptendpoint).be.a.Object();
+        should(scriptendpoint).have.property('name').which.is.String().equal(ModelData.name);
+        should(scriptendpoint).have.property('instanceName').which.is.String().equal(ModelData.instanceName);
+        should(scriptendpoint).have.property('description').which.is.String().equal(ModelData.description);
+        should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
+        should(scriptendpoint).have.property('links').which.is.Object();
+
+        return scriptendpoint.runPublic({}, '123');
       }).then((trace) => {
         should(trace).be.a.Object();
         should(trace).have.property('id').which.is.Number();
@@ -444,27 +488,28 @@ describe('ScriptEndpoint', function() {
       });
     });
 
-    it('should be able to run script', function() {
-    return Model(ModelData).save()
-      .then(cleaner.mark)
-      .then((scriptendpoint) => {
-        should(scriptendpoint).be.a.Object();
-        should(scriptendpoint).have.property('name').which.is.String().equal(ModelData.name);
-        should(scriptendpoint).have.property('instanceName').which.is.String().equal(ModelData.instanceName);
-        should(scriptendpoint).have.property('description').which.is.String().equal(ModelData.description);
-        should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
-        should(scriptendpoint).have.property('links').which.is.Object();
+    it('should be able to run script with cache_key', function() {
+      return Model(ModelData).save()
+        .then(cleaner.mark)
+        .then((scriptendpoint) => {
+          should(scriptendpoint).be.a.Object();
+          should(scriptendpoint).have.property('name').which.is.String().equal(ModelData.name);
+          should(scriptendpoint).have.property('instanceName').which.is.String().equal(ModelData.instanceName);
+          should(scriptendpoint).have.property('description').which.is.String().equal(ModelData.description);
+          should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
+          should(scriptendpoint).have.property('links').which.is.Object();
 
-        return Model.please().run(scriptendpoint);
-      }).then((trace) => {
-        should(trace).be.a.Object();
-        should(trace).have.property('id').which.is.Number();
-        should(trace).have.property('status').which.is.String();
-        should(trace).have.property('duration').which.is.Number();
-        should(trace).have.property('result').which.is.Object();
-        should(trace).have.property('executed_at').which.is.Date();
+          return Model.please().run(scriptendpoint, {}, '123');
+        }).then((trace) => {
+          should(trace).be.a.Object();
+          should(trace).have.property('id').which.is.Number();
+          should(trace).have.property('status').which.is.String();
+          should(trace).have.property('duration').which.is.Number();
+          should(trace).have.property('result').which.is.Object();
+          should(trace).have.property('executed_at').which.is.Date();
       });
-  });
+    });
+
 
   it('should be able to run *public* script', function() {
     return Model(ModelData).save()
@@ -478,6 +523,28 @@ describe('ScriptEndpoint', function() {
         should(scriptendpoint).have.property('links').which.is.Object();
 
         return Model.please().runPublic(scriptendpoint);
+      }).then((trace) => {
+        should(trace).be.a.Object();
+        should(trace).have.property('id').which.is.Number();
+        should(trace).have.property('status').which.is.String();
+        should(trace).have.property('duration').which.is.Number();
+        should(trace).have.property('result').which.is.Object();
+        should(trace).have.property('executed_at').which.is.Date();
+      });
+  });
+
+  it('should be able to run *public* script with cache_key', function() {
+    return Model(ModelData).save()
+      .then(cleaner.mark)
+      .then((scriptendpoint) => {
+        should(scriptendpoint).be.a.Object();
+        should(scriptendpoint).have.property('name').which.is.String().equal(ModelData.name);
+        should(scriptendpoint).have.property('instanceName').which.is.String().equal(ModelData.instanceName);
+        should(scriptendpoint).have.property('description').which.is.String().equal(ModelData.description);
+        should(scriptendpoint).have.property('script').which.is.Number().equal(ModelData.script);
+        should(scriptendpoint).have.property('links').which.is.Object();
+
+        return Model.please().runPublic(scriptendpoint, {}, '123');
       }).then((trace) => {
         should(trace).be.a.Object();
         should(trace).have.property('id').which.is.Number();


### PR DESCRIPTION
Via model instance: 

```
DataEndpoint.fetchData('123');
```

```
ScriptEndpoint.run(PAYLOAD_OBJECT, '123');
ScriptEndpoint.runPublic(PAYLOAD_OBJECT,, '123');
```

Or via querySet:

```
DataEndpoint.please().fetchData({name: dataEndpointName, instanceName}).cacheKey('123');
```

```
DataEndpoint.please().cacheKey('123').run(PROPERTIES_OBJECT);
DataEndpoint.please().cacheKey('123').runPublic(PROPERTIES_OBJECT);
```
