### PR TITLE
[LIB-776] getRelatedObjects() method for DataObject model instance

### DIFF
--- a/src/models/dataobject.js
+++ b/src/models/dataobject.js
@@ -295,7 +295,28 @@ const DataObject = stampit()
   .setMeta(DataObjectMeta)
   .methods({
     /**
-    * Increments single object field based on provided arguments
+    * Gets related objects via relation field name.
+
+    * @memberOf QuerySet
+    * @instance
+
+    * @param {String} field name.
+    * @returns {QuerySet}
+
+    * @example {@lang javascript}
+    * Object.getRelatedObjects('authors');
+
+    */
+    getRelatedObjects(field) {
+      if(!_.has(this, field)) return Promise.reject(new Error(`The ${field} field does not exist.`));
+      if(!_.has(this[field], 'value') || !_.isArray(this[field].value)) return Promise.reject(new Error(`The ${field} is not a relation.`));
+
+      const {DataObject} =  this.getConfig();
+
+      return DataObject.please().list({instanceName: this.instanceName, className: this[field].target }).filter({ id: { _in: this[field].value }});
+    },
+    /**
+    * Increments single object field based on provided arguments.
 
     * @memberOf QuerySet
     * @instance

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -428,6 +428,38 @@ describe('Dataobject', function() {
       })
   });
 
+  it('should be able to get related objects via model instance', function() {
+    let authorIds = null;
+
+    return Model.please().bulkCreate([Model(philipKDick), Model(charlesBukowski)])
+      .then(cleaner.mark)
+      .then((authors) => {
+        should(authors).be.an.Array().with.length(2);
+
+        authorIds = _.map(authors, (x) => x.id)
+
+        return Model({instanceName, className: 'books', title: 'Ubik', authors: authorIds}).save();
+      })
+      .then(cleaner.mark)
+      .then((book) => {
+        should(book).be.an.Object();
+        should(book).have.property('instanceName').which.is.String().equal(instanceName);
+        should(book).have.property('className').which.is.String().equal('books');
+        should(book).have.property('title').which.is.String().equal('Ubik');
+        should(book).have.property('authors').which.is.Object();
+        should(book.authors).have.property('target').which.is.String().equal('authors');
+        should(book.authors).have.property('value').which.is.Array().with.length(2);
+        should(book.authors.value[0]).be.a.Number().equal(authorIds[0]);
+        should(book.authors.value[1]).be.a.Number().equal(authorIds[1]);
+
+        return book.getRelatedObjects('authors');
+      })
+      .then((authors) => {
+        should(authors).be.an.Array().with.length(2);
+      })
+  });
+
+
   it('should be able to update via model instance', function() {
     return Model(dataObj).save()
       .then(cleaner.mark)


### PR DESCRIPTION
Added a method to get related objects via model instance. For example, let's say you have a book:

``` javascript
{
title: 'Book 1',
authors: [23, 24]
}
```

Where the authors field is a relation pointing to an `authors` class. When you get the book dataobject, you can call the `getRelatedObjects` method to get all of the referenced authors:

``` javascript
book.getRelatedObjects('authors')
  .then((authors) => {
    // authors objects
  });
```
