### PR TITLE
[Lib-780] all() method for querySets

### DIFF
--- a/src/querySet.js
+++ b/src/querySet.js
@@ -784,12 +784,17 @@ const AllObjects = stampit()
     timeout: 15000,
     path: null,
     abort: false,
-    model: null
+    model: null,
+    query: {}
   })
   .methods({
 
     request() {
-      return this.makeRequest('GET', this.path);
+      const options = {
+        query: this.query
+      }
+
+      return this.makeRequest('GET', this.path, options);
     },
 
     start() {
@@ -863,7 +868,7 @@ const AllObjects = stampit()
   */
 const All = stampit().methods({
 
-  all(properties = {}, start = true) {
+  all(properties = {}, query = {}, start = true) {
     this.properties = _.assign({}, this.properties, properties);
 
     const config = this.getConfig();
@@ -873,6 +878,7 @@ const All = stampit().methods({
     let options = {}
     options.path = path;
     options.model = this.model;
+    options.query = query;
 
     const allObjects = AllObjects.setConfig(config)(options);
 

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -6,7 +6,7 @@ import {ValidationError} from '../../src/errors';
 import {suffix, credentials, createCleaner} from './utils';
 
 describe('Dataobject', function() {
-  this.timeout(15000);
+  this.timeout(65000);
 
   const cleaner = createCleaner();
   let connection = null;
@@ -505,6 +505,24 @@ describe('Dataobject', function() {
       return Model.please().list({instanceName, className}).then((dataobjects) => {
         should(dataobjects).be.an.Array();
       });
+    });
+
+    it('should be able to fetch all objects', function(done) {
+      return Promise
+        .mapSeries(_.range(200), (int) => Model({instanceName, className: authorsClass.name, name: 'Somebody', year_born: int}).save())
+        .then(cleaner.mark)
+        .then(() => {
+          let all = Model.please().all({instanceName, className: authorsClass.name});
+
+          all.on('page', function(page) {
+            should(page).be.an.Array().with.length(100);
+          });
+
+          all.on('stop', function() {
+            done();
+          })
+
+        });
     });
 
     it('should be able to save with an array field', function() {

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -509,13 +509,13 @@ describe('Dataobject', function() {
 
     it('should be able to fetch all objects', function(done) {
       return Promise
-        .mapSeries(_.range(200), (int) => Model({instanceName, className: authorsClass.name, name: 'Somebody', year_born: int}).save())
+        .mapSeries(_.range(30), (int) => Model({instanceName, className: authorsClass.name, name: 'Somebody', year_born: int}).save())
         .then(cleaner.mark)
         .then(() => {
-          let all = Model.please().all({instanceName, className: authorsClass.name});
+          let all = Model.please().all({instanceName, className: authorsClass.name}, { page_size: 10});
 
           all.on('page', function(page) {
-            should(page).be.an.Array().with.length(100);
+            should(page).be.an.Array().with.length(10);
           });
 
           all.on('stop', function() {

--- a/test/integration/dataobjectsTest.js
+++ b/test/integration/dataobjectsTest.js
@@ -512,7 +512,7 @@ describe('Dataobject', function() {
         .mapSeries(_.range(30), (int) => Model({instanceName, className: authorsClass.name, name: 'Somebody', year_born: int}).save())
         .then(cleaner.mark)
         .then(() => {
-          let all = Model.please().all({instanceName, className: authorsClass.name}, { page_size: 10});
+          const all = Model.please().all({instanceName, className: authorsClass.name}, { page_size: 10});
 
           all.on('page', function(page) {
             should(page).be.an.Array().with.length(10);


### PR DESCRIPTION
Added a method for downloading all objects of a type:

```
const all = DataObject.please().all({instanceName, className});

all.on('page', function(page) {
  // a page is fetched
});

all.on('stop', function() {
  // finished fetching pages
});
```

If you want to stop fetching pages, you can use the `stop()` method:

```
all.stop();
```

Filters are also supported:

```
DataObject.please().all({instanceName, className}, { page_size: 10});
```
