### PR TITLE
[LIB-794] Add mapDefaults prop to model meta to map over default prop…

### DIFF
--- a/src/models/base.js
+++ b/src/models/base.js
@@ -269,6 +269,13 @@ export const Model = stampit({
     please(properties = {}) {
       const querySet = this.getQuerySet();
       const defaultProps = _.assign({}, this.getDefaultProperties(), properties);
+      const {mapDefaults} = this.getMeta();
+      _.forOwn(defaultProps, (v, k) => {
+        if(_.has(mapDefaults, k)) {
+          _.set(defaultProps, [mapDefaults[k]], v)
+          _.unset(defaultProps, k);
+        }
+      });
       return querySet({
         model: this,
         properties: defaultProps,

--- a/src/models/instance.js
+++ b/src/models/instance.js
@@ -48,7 +48,10 @@ const InstanceMeta = Meta({
     'Admin', 'Class', 'Script', 'Schedule', 'InstanceInvitation', 'ApiKey'
     , 'Trigger', 'ScriptEndpoint', 'User', 'Group', 'GCMDevice', 'Channel'
     , 'APNSDevice', 'Template'
-  ]
+  ],
+  mapDefaults: {
+    instanceName: 'name'
+  }
 });
 
 const InstanceConstraints = {


### PR DESCRIPTION
…erties in querySets, so when you do:

``` javascript
const connection = Syncano({ defaults: { instanceName: 'instance'});
```

It will be mapped to the `name` param in the `querySet`:

``` javascript
connection.Instance.please().get() // the 'name' param is taken from the defaults object
```
