### PR TITLE
[LIB-833] DataObject creation via DataEndpoint

### DIFF
--- a/src/models/dataendpoint.js
+++ b/src/models/dataendpoint.js
@@ -32,6 +32,7 @@ const DataEndpointQerySet = stampit().compose(QuerySet, Filter, QsRename).method
   * @memberOf DataEndpointQerySet
   * @instance
 
+  * @param {Object} properties lookup properties used for path resolving
   * @returns {DataEndpointQerySet}
 
   * @example {@lang javascript}
@@ -43,6 +44,28 @@ const DataEndpointQerySet = stampit().compose(QuerySet, Filter, QsRename).method
 
     this.method = 'POST';
     this.endpoint = 'clear_cache';
+
+    return this;
+  },
+  /**
+  * Creates a DataObject in a DataEndpoint.
+  * @memberOf DataEndpointQerySet
+  * @instance
+
+  * @param {Object} properties lookup properties used for path resolving
+  * @param {Object} paylod DataObject data
+  * @returns {DataEndpointQerySet}
+
+  * @example {@lang javascript}
+  * DataEndpoint.please().createDataObject({name: 'dataViewName', instanceName: 'test-one'}, { field: 'value' });
+
+  */
+  createDataObject(properties = {}, payload ={}) {
+    this.properties = _.assign({}, this.properties, properties);
+
+    this.method = 'POST';
+    this.endpoint = 'post';
+    this.payload = payload;
 
     return this;
   }
@@ -60,6 +83,10 @@ const DataEndpointMeta = Meta({
     'list': {
       'methods': ['post', 'get'],
       'path': '/v1.1/instances/{instanceName}/endpoints/data/'
+    },
+    'post': {
+      'methods': ['post'],
+      'path': '/v1.1/instances/{instanceName}/endpoints/data/{name}/post/'
     },
     'get': {
       'methods': ['get'],
@@ -176,6 +203,24 @@ const DataEndpoint = stampit()
       const path = meta.resolveEndpointPath('clear_cache', this);
 
       return this.makeRequest('POST', path);
+    },
+    /**
+    * Creates a DataObject in a DataEndpoint.
+    * @memberOf DataEndpointQerySet
+    * @instance
+
+    * @param {Object} paylod DataObject data
+    * @returns {DataEndpointQerySet}
+
+    * @example {@lang javascript}
+    * DataEndpoint.createDataObject({ field: 'value' });
+
+    */
+    createDataObject(payload = {}) {
+      const meta = this.getMeta();
+      const path = meta.resolveEndpointPath('post', this);
+
+      return this.makeRequest('POST', path, payload);
     }
 
   });

--- a/test/integration/dataEndpointsTest.js
+++ b/test/integration/dataEndpointsTest.js
@@ -185,9 +185,7 @@ describe('DataEndpoint', function() {
       })
       .then((data) => {
         should(data).be.an.Object();
-        should(data).have.property('objects').which.is.Array();
-        should(data.objects[0]).have.property('int').which.is.Number().equal(9);
-        should(data.objects.length).equal(5);
+        should(data).have.property('objects').which.is.Array().with.length(5);
       });
   });
 
@@ -296,7 +294,7 @@ describe('DataEndpoint', function() {
         })
         .then((data) => {
           should(data).be.an.Object();
-          should(data).have.property('objects').which.is.Array().with.length(1);
+          should(data).have.property('objects').which.is.Array().with.length(2);
         })
     });
 
@@ -394,9 +392,7 @@ describe('DataEndpoint', function() {
         })
         .then((data) => {
           should(data).be.an.Object();
-          should(data).have.property('objects').which.is.Array();
-          should(data.objects[0]).have.property('int').which.is.Number().equal(9);
-          should(data.objects.length).equal(5);
+          should(data).have.property('objects').which.is.Array().with.length(5);
         });
     });
 
@@ -449,9 +445,7 @@ describe('DataEndpoint', function() {
         })
         .then((data) => {
           should(data).be.an.Object();
-          should(data).have.property('objects').which.is.Array();
-          should(data.objects[0]).have.property('int').which.is.Number().equal(9);
-          should(data.objects.length).equal(5);
+          should(data).have.property('objects').which.is.Array().with.length(5);
         });
     });
 

--- a/test/integration/dataEndpointsTest.js
+++ b/test/integration/dataEndpointsTest.js
@@ -123,6 +123,37 @@ describe('DataEndpoint', function() {
       });
   });
 
+  it('should be able to create a DataObject via model instance', function() {
+    let dataEndpoint = null;
+
+    return Model(data).save()
+      .then(cleaner.mark)
+      .then((dta) => {
+        should(dta).be.a.Object();
+        should(dta).have.property('name').which.is.String().equal(data.name);
+        should(dta).have.property('description').which.is.String().equal(data.description);
+        should(dta).have.property('instanceName').which.is.String().equal(data.instanceName);
+        should(dta).have.property('query').which.is.Object();
+        should(dta).have.property('excluded_fields').which.is.Null();
+        should(dta).have.property('order_by').which.is.String().equal(data.order_by);
+        should(dta).have.property('page_size').which.is.Number().equal(data.page_size);
+        should(dta).have.property('expand').which.is.Null();
+        should(dta).have.property('links').which.is.Object();
+        should(dta).have.property('class').which.is.String().equal(data.class);
+
+        dataEndpoint = dta;
+
+        return dataEndpoint.createDataObject({ int: 1})
+      })
+      .then(() => {
+        return dataEndpoint.fetchData();
+      })
+      .then((data) => {
+        should(data).be.an.Object();
+        should(data).have.property('objects').which.is.Array().with.length(1);
+      })
+  });
+
   it('should be able to fetch DataObjects via model instance with filtering', function() {
     return dataObject.please().bulkCreate(dataobjects)
       .then(cleaner.mark)
@@ -240,6 +271,33 @@ describe('DataEndpoint', function() {
           should(dta).have.property('links').which.is.Object();
           should(dta).have.property('class').which.is.String().equal(data.class)
         });
+    });
+
+    it('should be able to create a DataObject', function() {
+      return Model.please().create(data)
+        .then(cleaner.mark)
+        .then((dta) => {
+          should(dta).be.a.Object();
+          should(dta).have.property('name').which.is.String().equal(data.name);
+          should(dta).have.property('description').which.is.String().equal(data.description);
+          should(dta).have.property('instanceName').which.is.String().equal(data.instanceName);
+          should(dta).have.property('query').which.is.Object();
+          should(dta).have.property('excluded_fields').which.is.Null();
+          should(dta).have.property('order_by').which.is.String().equal(data.order_by);
+          should(dta).have.property('page_size').which.is.Number().equal(data.page_size);
+          should(dta).have.property('expand').which.is.Null();
+          should(dta).have.property('links').which.is.Object();
+          should(dta).have.property('class').which.is.String().equal(data.class)
+
+          return Model.please().createDataObject({instanceName, name: dataEndpointName}, { int: 1});
+        })
+        .then(() => {
+          return Model.please().fetchData({instanceName, name: dataEndpointName});
+        })
+        .then((data) => {
+          should(data).be.an.Object();
+          should(data).have.property('objects').which.is.Array().with.length(1);
+        })
     });
 
     it('should be able to rename a Model', function() {


### PR DESCRIPTION
Via model instance:

``` javascript
DataEndpoint.createDataObject({data});
```

Via querySet:

``` javascript
DataEndpoint.please().createDataObject({instanceName, name}, {data});
```
