### PR TITLE
[LIB-845] Enhancements for Channel polling

### DIFF
--- a/src/eventemitter.js
+++ b/src/eventemitter.js
@@ -8,23 +8,32 @@ export default function EventEmitter() {
     this.events = {};
 }
 
-EventEmitter.prototype.on = function (event, listener) {
+EventEmitter.prototype.on = function(event, listener) {
     if (!_.isArray(this.events[event])) {
         this.events[event] = [];
     }
     this.events[event].push(listener);
 };
 
-EventEmitter.prototype.removeListener = function (event, listener) {
+EventEmitter.prototype.removeListener = function(event, listener) {
     if (_.isArray(this.events[event])) {
         _.pull(this.events[event], listener);
     }
 };
 
-EventEmitter.prototype.emit = function (event) {
+EventEmitter.prototype.removeListeners = function(event) {
+  if (_.isArray(this.events[event])) {
+    this.events[event] = [];
+  }
+};
+
+EventEmitter.prototype.removeAllListeners = function() {
+  this.events = {};
+};
+
+EventEmitter.prototype.emit = function(event, ...args) {
     if (_.isArray(this.events[event])) {
-        const listeners = this.events[event].slice();
-        const args = [].slice.call(arguments, 1);
+        const listeners = this.events[event];
         _.forEach(listeners, (listener) => listener.apply(this, args));
     }
 };

--- a/src/models/channel.js
+++ b/src/models/channel.js
@@ -287,8 +287,11 @@ export const ChannelPoll = stampit()
       return this.stop;
     },
 
-    stop() {
+    stop(removeListeners = false) {
       this.abort = true;
+      if(removeListeners) {
+        this.removeAllListeners();
+      }
       return this;
     }
 


### PR DESCRIPTION
As requested by @hwesol13:
- The `stop()` method can be called with a boolean param which allows you to remove all the previously added event listeners: `poll.stop(true)`
- There are two new methods for removing listeners: `removeListeners(event)` and `removeAllListeners()`. Pretty self explanatory ;)
