### PR TITLE
[LIB-903] Ability to listen to progress event

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -180,6 +180,12 @@ const Request = stampit().compose(ConfigMixin, Logger)
         }, request.type('form'));
       }
 
+      request.on('progress', (e) => {
+        if(_.isFunction(this.getConfig().progressCallback)) {
+          this.getConfig().progressCallback(e);
+        }
+      });
+
       return Promise.promisify(request.end, {context: request})()
         .then((response) => {
           if (!response.ok) {

--- a/src/syncano.js
+++ b/src/syncano.js
@@ -39,6 +39,7 @@ const Syncano = stampit()
   })
   .refs({
     baseUrl: 'https://api.syncano.io',
+    progressCallback: null,
     accountKey: null,
     userKey: null,
     apiKey: null,
@@ -69,6 +70,21 @@ const Syncano = stampit()
       }
       return this;
     },
+
+    /**
+     * Sets progressCallback
+     *
+     * @memberOf Syncano
+     * @instance
+     *
+     * @param {Function} callback Function to be called on 'progress' event
+     * @returns {Syncano}
+     */
+    onProgress(callback) {
+      this.progressCallback = callback;
+      return this;
+    },
+
     /**
     * Gets *instanceName*.
 

--- a/test/lib/requestTest.js
+++ b/test/lib/requestTest.js
@@ -20,7 +20,8 @@ describe('Request', function() {
       'send',
       'attach',
       'field',
-      'end'
+      'end',
+      'on'
     ];
 
     stubs = _.reduce(methods, (result, method) => {


### PR DESCRIPTION
You can now attach a callback fired on every `progress` event dispatched from the requests:

``` javascript
const connection = Syncano({ apiKey });

connection.onProgress((data) => {
  console.log(data);
  // { direction: 'upload',
  // lengthComputable: true,
  // loaded: 124,
  // total: 3777 }
});
```

To remove the callback, just set it to null: `connection.onProgress(null);`.

The event is fired only when using `form-data` requests (containing files).
